### PR TITLE
Decouple rust contracts into respective releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,8 @@ jobs:
         run: |
           rustup toolchain install stable --profile minimal
           rustup target add wasm32-unknown-unknown
+          rustc --version
+          cargo --version
 
       - name: Setup rust cache
         uses: Swatinem/rust-cache@v2
@@ -139,6 +141,7 @@ jobs:
           mkdir -p "$HOME/.local/bin"
           mv "$TMPDIR/candid-extractor" "$HOME/.local/bin/"
           rm -rf "$TMPDIR"
+          candid-extractor --version
 
       - name: Install wasm-opt
         run: |
@@ -150,14 +153,16 @@ jobs:
           mkdir -p "$HOME/.local/bin"
           mv "$TMPDIR/binaryen-$VERSION/bin/"* "$HOME/.local/bin/"
           rm -rf "$TMPDIR"
+          wasm-opt --version
 
       - name: Build Rust contracts
         run: ./scripts/build-rust.sh
 
-      - name: Create archive
+      - name: Create protocol archives
         run: |
-          tmp_dir=$(mktemp -d)
+          mkdir -p artifacts
           for protocol in $(echo '${{ needs.prepare.outputs.rust_protocol_matrix }}' | jq -r '.[]'); do
+            tmp_dir=$(mktemp -d)
             for contract in "contracts/${protocol}"/*; do
               if [ -d "${contract}" ]; then
                 find "${contract}/res" -maxdepth 1 -type f -exec cp {} "$tmp_dir" \;
@@ -166,10 +171,9 @@ jobs:
                 fi
               fi
             done
+            tar -czf "artifacts/${protocol}.tar.gz" -C "$tmp_dir" .
+            rm -rf "$tmp_dir"
           done
-          mkdir -p artifacts
-          tar -czf "artifacts/rust.tar.gz" -C "$tmp_dir" .
-          rm -rf "$tmp_dir"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -195,6 +199,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           version: stable
+      - run: forge --version
 
       - name: Build Solidity contracts
         run: ./scripts/build-solidity.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -517,7 +517,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-config-icp"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bs58 0.5.1",
  "calimero-context-config",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-config-near"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "calimero-context-config",
  "cfg-if 1.0.0",
@@ -550,7 +550,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-config-stellar"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "calimero-context-config",
  "ed25519-dalek",
@@ -561,7 +561,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-proxy-icp"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "bs58 0.5.1",
  "calimero-context-config",
@@ -581,7 +581,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-proxy-near"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "calimero-context-config",
  "calimero-context-config-near",
@@ -598,7 +598,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-proxy-stellar"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "calimero-context-config",
  "ed25519-dalek",
@@ -636,7 +636,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-registry"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "hex",
  "near-sdk",

--- a/contracts/icp/README.md
+++ b/contracts/icp/README.md
@@ -1,0 +1,92 @@
+## Calimero ICP Contracts
+
+Smart contracts for the Calimero Internet Computer Protocol (ICP) implementation.
+
+This repository contains:
+- **Context Config**: Factory contract for creating and managing contexts
+- **Context Proxy**: Multi-signature contract implementation
+- **Mock**: Test contracts for integration testing
+
+## Development Tools
+
+Required tools:
+- **dfx**: ICP development toolkit ([installation guide](https://internetcomputer.org/docs/current/developer-docs/setup/install/))
+- **candid-extractor**: For Candid interface generation
+- **Rust**: For contract compilation
+
+Note: The development environment uses dfx version 0.24.3
+
+## Development Workflow
+
+### Building Contracts
+
+Each contract has its own build script:
+
+```shell
+# Build Context Config
+$ cd context-config
+$ ./build.sh
+
+# Build Context Proxy
+$ cd ../context-proxy
+$ ./build.sh
+
+# Build Mock contracts
+$ cd context-proxy/mock
+$ ./build.sh
+```
+
+Each build script will:
+1. Add wasm32-unknown-unknown target if not present
+2. Compile the contract with app-release profile
+3. Generate Candid interface (if candid-extractor is available)
+4. Artifacts are automatically placed in the `res` directory
+
+### Local Development
+
+To spin up a local devnet with all contracts deployed:
+
+```shell
+$ cd context-config
+$ ./deploy_devnet.sh
+```
+
+This will:
+1. Check for required dependencies (dfx, cargo, candid-extractor)
+2. Set up dfx identities for testing (minting, initial, archive, recipient)
+3. Start a clean dfx instance
+4. Deploy and configure:
+   - Context Contract
+   - Ledger Canister
+   - Mock External Contract
+5. Set up the proxy code
+
+Example output:
+
+=== Deployment Summary ===
+Context Contract ID: ${CONTEXT_ID}
+Ledger Contract ID: ${LEDGER_ID}
+Account Information:
+Minting Account: ${MINTING_ACCOUNT}
+Initial Account: ${INITIAL_ACCOUNT}
+Archive Principal: ${ARCHIVE_PRINCIPAL}
+Recipient Principal: ${RECIPIENT_PRINCIPAL}
+Mock External Contract ID: ${MOCK_EXTERNAL_ID}
+Deployment completed successfully!
+
+### Testing
+
+Run tests for each contract in its respective directory:
+
+```shell
+$ cd context-config
+$ cargo test
+
+$ cd ../context-proxy
+$ cargo test
+```
+
+For verbose output:
+```shell
+$ cargo test -- --nocapture
+```

--- a/contracts/icp/context-config/Cargo.toml
+++ b/contracts/icp/context-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-config-icp"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/contracts/icp/context-proxy/Cargo.toml
+++ b/contracts/icp/context-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-proxy-icp"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/contracts/near/context-config/Cargo.toml
+++ b/contracts/near/context-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-config-near"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/contracts/near/context-proxy/Cargo.toml
+++ b/contracts/near/context-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-proxy-near"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/contracts/near/registry/Cargo.toml
+++ b/contracts/near/registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-registry"
-version = "0.4.1"
+version = "0.5.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/contracts/stellar/README.md
+++ b/contracts/stellar/README.md
@@ -1,0 +1,85 @@
+## Calimero Stellar Contracts
+
+Smart contracts for the Calimero Stellar Protocol implementation.
+
+This repository contains:
+- **Context Config**: Factory contract for creating and managing contexts
+- **Context Proxy**: Multi-signature contract implementation
+- **Mock**: Test contracts for integration testing
+
+## Development Tools
+
+Required tools:
+- **stellar**: Stellar CLI
+- **docker**: For running Stellar Quickstart container
+- **Rust**: For contract compilation
+
+## Development Workflow
+
+### Building Contracts
+
+Each contract has its own build script:
+
+```shell
+# Build Context Config
+$ cd context-config
+$ ./build.sh
+
+# Build Context Proxy
+$ cd ../context-proxy
+$ ./build.sh
+
+# Build Mock contracts
+$ cd context-proxy/mock
+$ ./build.sh
+```
+
+Each build script will:
+1. Add wasm32-unknown-unknown target if not present
+2. Compile the contract with app-release profile
+3. Optimize Wasm binary if wasm-opt is available
+4. Artifacts are automatically placed in the `res` directory
+
+### Local Development
+
+To spin up a local devnet with all contracts deployed:
+
+```shell
+$ cd context-config
+$ ./deploy_devnet.sh
+```
+
+This will:
+1. Check for required dependencies (stellar CLI, docker)
+2. Start Stellar Quickstart container
+3. Set up local network configuration
+4. Generate and fund test account
+5. Deploy and configure:
+   - Context Contract
+   - Set proxy code
+   - Mock External Contract
+
+Example output:
+```
+Contract ID: ${CONTRACT_ID}
+Account address: ${ACCOUNT_ADDRESS}
+Secret key: ${SECRET_KEY}
+External contract ID: ${EXTERNAL_CONTRACT_ID}
+```
+
+### Testing
+
+Run tests for each contract in its respective directory:
+
+```shell
+$ cd context-config
+$ cargo test
+
+$ cd ../context-proxy
+$ cargo test
+```
+
+For verbose output:
+```shell
+$ cargo test -- --nocapture
+```

--- a/contracts/stellar/context-config/Cargo.toml
+++ b/contracts/stellar/context-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-config-stellar"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/contracts/stellar/context-proxy/Cargo.toml
+++ b/contracts/stellar/context-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-proxy-stellar"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
# Short description

Decouple Rust Contracts (ICP, Stellar, NEAR) from one file to separate files during the release process
Added check for dependency installation
Bumped contracts version to 0.5.0
Added README files to Stellar and ICP 

## Test plan

[Correct release format](https://github.com/calimero-network/contracts/releases/tag/prerelease-8)

## Documentation update

N/A