### PR TITLE
fix: contracts build script should use zksync forge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,15 +182,11 @@ jobs:
           path: artifacts/*
           retention-days: 2
 
-  build-solidity:
-    name: Build Solidity
+  build-ethereum:
+    name: Build Ethereum
     if: needs.prepare.outputs.build_required == 'true'
     runs-on: ubuntu-latest
     needs: prepare
-    strategy:
-      matrix:
-        protocol: ${{ fromJson(needs.prepare.outputs.solidity_protocol_matrix) }}
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -201,13 +197,13 @@ jobs:
           version: stable
       - run: forge --version
 
-      - name: Build Solidity contracts
-        run: ./scripts/build-solidity.sh
+      - name: Build Ethereum contracts
+        run: ./scripts/build-ethereum.sh
 
       - name: Create archive
         run: |
           tmp_dir=$(mktemp -d)
-          for contract in "contracts/${{ matrix.protocol }}"/*; do
+          for contract in "contracts/ethereum"/*; do
             if [ -d "${contract}" ]; then
               cp -r "${contract}/out" "$tmp_dir/"
               if [ -d "${contract}/mock/out" ]; then
@@ -216,13 +212,57 @@ jobs:
             fi
           done
           mkdir -p artifacts
-          tar -czf "artifacts/${{ matrix.protocol }}.tar.gz" -C "$tmp_dir" .
+          tar -czf "artifacts/ethereum.tar.gz" -C "$tmp_dir" .
           rm -rf "$tmp_dir"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: artifacts-${{ matrix.protocol }}
+          name: artifacts-ethereum
+          path: artifacts/*
+          retention-days: 2
+
+  build-zksync:
+    name: Build ZKsync
+    if: needs.prepare.outputs.build_required == 'true'
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install ZKsync Foundry
+        run: |
+          wget -qc https://github.com/matter-labs/foundry-zksync/releases/download/nightly/foundry_nightly_linux_amd64.tar.gz -O - | tar -xz
+          sudo mv ./forge /usr/local/bin/
+          forge -V
+
+      - name: Build ZKsync contracts
+        run: ./scripts/build-zksync.sh
+
+      - name: Create archive
+        run: |
+          tmp_dir=$(mktemp -d)
+          for contract in "contracts/zksync"/*; do
+            if [ -d "${contract}" ]; then
+              # Copy the build artifacts from the contract directory
+              if [ -d "${contract}/out" ]; then
+                find "${contract}/out" -maxdepth 1 -type f -exec cp {} "$tmp_dir" \;
+              fi
+              # Copy mock artifacts if they exist
+              if [ -d "${contract}/mock/out" ]; then
+                find "${contract}/mock/out" -maxdepth 1 -type f -exec cp {} "$tmp_dir" \;
+              fi
+            fi
+          done
+          mkdir -p artifacts
+          tar -czf "artifacts/zksync.tar.gz" -C "$tmp_dir" .
+          rm -rf "$tmp_dir"
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: artifacts-zksync
           path: artifacts/*
           retention-days: 2
 
@@ -230,7 +270,7 @@ jobs:
     name: Release
     if: needs.prepare.outputs.release_required == 'true'
     runs-on: ubuntu-latest
-    needs: [prepare, build-rust, build-solidity]
+    needs: [prepare, build-rust, build-ethereum, build-zksync]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/contracts/zksync/context-config/build.sh
+++ b/contracts/zksync/context-config/build.sh
@@ -3,8 +3,8 @@ set -ex
 
 cd "$(dirname $0)"
 
-# Install dependencies first
-forge install --no-git foundry-rs/forge-std
+# Install dependencies
+forge install --no-commit foundry-rs/forge-std
 
-# Then build
-forge build
+# Build using forge with zksync flag
+forge build --zksync

--- a/contracts/zksync/context-proxy/build.sh
+++ b/contracts/zksync/context-proxy/build.sh
@@ -3,8 +3,8 @@ set -ex
 
 cd "$(dirname $0)"
 
-# Install dependencies first
-forge install --no-git foundry-rs/forge-std
+# Install dependencies
+forge install --no-commit foundry-rs/forge-std
 
-# Then build
-forge build
+# Build using forge with zksync flag
+forge build --zksync

--- a/contracts/zksync/context-proxy/mock/build.sh
+++ b/contracts/zksync/context-proxy/mock/build.sh
@@ -3,8 +3,8 @@ set -ex
 
 cd "$(dirname $0)"
 
-# Install dependencies first
-forge install --no-git foundry-rs/forge-std
+# Install dependencies
+forge install --no-commit foundry-rs/forge-std
 
-# Then build
-forge build
+# Build using forge with zksync flag
+forge build --zksync

--- a/scripts/build-ethereum.sh
+++ b/scripts/build-ethereum.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Builds all Ethereum solidity components of the project
+# This script is intended to be run from the root of the project
+
+# Exit immediately if a command exits with a non-zero status.
+set -ex
+
+# Build contracts
+contracts/ethereum/context-config/build.sh
+contracts/ethereum/context-proxy/build_contracts.sh 

--- a/scripts/build-zksync.sh
+++ b/scripts/build-zksync.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Builds all ZKsync solidity components of the project
+# This script is intended to be run from the root of the project
+
+# Exit immediately if a command exits with a non-zero status.
+set -ex
+
+# Build contracts
+contracts/zksync/context-config/build.sh
+contracts/zksync/context-proxy/build_contracts.sh 


### PR DESCRIPTION
contracts build script should use zksync forge

Please include a short description of the change and which issue is fixed.
Please also include relevant motivation and context. List any dependencies that
are required for this change.

## Test plan

./contracts/zksync/context-proxy/build_contracts.sh

## Documentation update
Will update all in following PRs, once fully fixed the rest.
