### PR TITLE
feat(proxy): set default proposal approval threshold to 1

### DIFF
--- a/contracts/ethereum/context-proxy/src/ContextProxy.sol
+++ b/contracts/ethereum/context-proxy/src/ContextProxy.sol
@@ -113,7 +113,7 @@ contract ContextProxy {
     constructor(bytes32 _contextId, address _owner) {
         contextId = _contextId;
         contextConfigId = _owner;
-        numApprovals = 3;
+        numApprovals = 1;
         activeProposalsLimit = 10;
     }
 

--- a/contracts/icp/context-proxy/src/lib.rs
+++ b/contracts/icp/context-proxy/src/lib.rs
@@ -37,7 +37,7 @@ fn init(context_id: ICRepr<ContextId>, ledger_id: Principal) {
         *contract.borrow_mut() = Some(ICProxyContract {
             context_id,
             context_config_id: ic_cdk::caller(),
-            num_approvals: 3,
+            num_approvals: 1,
             proposals: BTreeMap::new(),
             approvals: BTreeMap::new(),
             num_proposals_pk: BTreeMap::new(),

--- a/contracts/near/context-proxy/src/lib.rs
+++ b/contracts/near/context-proxy/src/lib.rs
@@ -65,7 +65,7 @@ impl ProxyContract {
             proposals: IterableMap::new(b"r".to_vec()),
             approvals: IterableMap::new(b"c".to_vec()),
             num_proposals_pk: IterableMap::new(b"k".to_vec()),
-            num_approvals: 3,
+            num_approvals: 1,
             active_proposals_limit: 10,
             context_storage: IterableMap::new(b"l"),
             code_size: (env::storage_usage(), None),

--- a/contracts/stellar/context-proxy/src/lib.rs
+++ b/contracts/stellar/context-proxy/src/lib.rs
@@ -61,7 +61,7 @@ impl ContextProxyContract {
         let state = ProxyState {
             context_id,
             context_config_id: owner,
-            num_approvals: 3,
+            num_approvals: 1,
             proposals: Map::new(&env),
             approvals: Map::new(&env),
             num_proposals_pk: Map::new(&env),

--- a/contracts/zksync/context-proxy/src/ContextProxy.sol
+++ b/contracts/zksync/context-proxy/src/ContextProxy.sol
@@ -130,7 +130,7 @@ contract ContextProxy {
     constructor(bytes32 _contextId, address _owner) {
         contextId = _contextId;
         contextConfigId = _owner;
-        numApprovals = 3;
+        numApprovals = 1;
         activeProposalsLimit = 10;
     }
 


### PR DESCRIPTION
resolves https://github.com/calimero-network/core/issues/1108

This PR changes the default proposal approval threshold from 3 to 1 across all proxy contract implementations (NEAR, Stellar, ICP, zkSync, Ethereum). The change simplifies development and testing while maintaining the ability to increase the threshold via proposals when needed.

## Test plan



## Documentation update


