### PR TITLE
ci: use stable 2024 edition version of rustfmt. Expand fmt options

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -54,9 +54,8 @@ jobs:
       - name: Cargo format
         shell: bash
         run: |
-          rustup toolchain install nightly
-          rustup component add rustfmt --toolchain nightly
-          cargo +nightly fmt -- --check
+          rustup component add rustfmt
+          cargo fmt --check
 
       - name: Cargo clippy
         run: cargo clippy -- -A warnings

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,7 @@
-group_imports = "StdExternalCrate"
-imports_granularity = "Module"
+edition = "2024"
+reorder_imports = true
+use_try_shorthand = true
+
+# These options are useful for formatting & merging imports, however they are only available in nightly toolchain.
+# group_imports = "StdExternalCrate"
+# imports_granularity = "Module"


### PR DESCRIPTION
# CI: use stable 2024 edition version of rustfmt. Expand fmt options

This PR updates our rustfmt setup to use the stable channel and the 2024 edition. This is essential to ensure code consistency.

The nightly `rustfmt`'s rules can change with the version upgrade, leading to unwanted formatting changes in PRs. This clutters diffs with stylistic fixes, making code reviews more difficult and hiding the true purpose of a PR.

By using the stable `rustfmt`, we guarantee fixed formatting behavior for Rust code. This means having less of stylystic changes in untouched code due to nightly version upgrades.

Additionally, we set to use the 2024 edition for formatting, we support an official style guide, making the code compaitble with [RFC 3338](https://rust-lang.github.io/rfcs/3338-style-evolution.html).

## Test plan

--

## Documentation update

--
