### PR TITLE
chore: release version 0.6.0

### DIFF
--- a/contracts/icp/context-config/Cargo.toml
+++ b/contracts/icp/context-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-config-icp"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/contracts/icp/context-proxy/Cargo.toml
+++ b/contracts/icp/context-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-proxy-icp"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 
 [lib]

--- a/contracts/near/context-config/Cargo.toml
+++ b/contracts/near/context-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-config-near"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/contracts/near/context-proxy/Cargo.toml
+++ b/contracts/near/context-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-context-proxy-near"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/contracts/near/context-proxy/mock/Cargo.toml
+++ b/contracts/near/context-proxy/mock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-mock-external-near"
-version = "0.4.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true

--- a/contracts/near/registry/Cargo.toml
+++ b/contracts/near/registry/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "calimero-registry"
-version = "0.5.0"
+version = "0.6.0"
 authors.workspace = true
 edition.workspace = true
 repository.workspace = true


### PR DESCRIPTION
# Release version 0.6.0.

* Bump Rust contracts (near, icp) version to 0.6.0.

## Test plan

--

## Documentation update

--
