### PR TITLE
chore(ci): run Rust fmt check before the build

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -48,14 +48,14 @@ jobs:
           rm -rf "$TMPDIR"
           wasm-opt --version
 
-      - name: Build Rust
-        run: ./scripts/build-rust.sh
-
       - name: Cargo format
         shell: bash
         run: |
           rustup component add rustfmt
           cargo fmt --check
+
+      - name: Build Rust
+        run: ./scripts/build-rust.sh
 
       - name: Cargo clippy
         run: cargo clippy -- -A warnings


### PR DESCRIPTION
# CI: run Rust formatting check before the build

While building the Rust binary might take a couple of minutes, the formatting check is less resource-intensive and almost immediate. By changing the order, we ensure that CI fails early without consuming too much of the compute time unnecessary.

## Test plan

--

## Documentation update

--
