### PR TITLE
chore(build): update contracts version in `Cargo.lock` with v0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-config-icp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bs58 0.5.1",
  "calimero-context-config",
@@ -377,7 +377,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-config-near"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "calimero-context-config",
  "cfg-if 1.0.0",
@@ -395,7 +395,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-proxy-icp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bs58 0.5.1",
  "calimero-context-config",
@@ -415,7 +415,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-context-proxy-near"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "calimero-context-config",
  "calimero-context-config-near",
@@ -442,7 +442,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-mock-external-near"
-version = "0.4.0"
+version = "0.6.0"
 dependencies = [
  "eyre",
  "near-sdk",
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "calimero-registry"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "hex",
  "near-sdk",


### PR DESCRIPTION
# Update contracts version in `Cargo.lock` with v0.6.

--

## Test plan

--

## Documentation update

--
